### PR TITLE
tests: add test scenario for block size truncation

### DIFF
--- a/tests/test_truncate.toml
+++ b/tests/test_truncate.toml
@@ -446,7 +446,6 @@ code = '''
             LFS_O_RDWR | LFS_O_CREAT) => 0;
 
     uint8_t bad_byte = 2;
-    uint8_t *wb = buffer;
     uint8_t *rb = buffer + cfg.block_size;
 
     /* Write a series of 1s to the first block */

--- a/tests/test_truncate.toml
+++ b/tests/test_truncate.toml
@@ -447,28 +447,28 @@ code = '''
 
     uint8_t bad_byte = 2;
     uint8_t *wb = buffer;
-    uint8_t *rb = buffer + cfg->block_size;
+    uint8_t *rb = buffer + cfg.block_size;
 
     /* Write a series of 1s to the first block */
-    memset(buffer, 1, cfg->block_size);
+    memset(buffer, 1, cfg.block_size);
     lfs_file_write(&lfs, &file, buffer,
-                   cfg->block_size) => cfg->block_size;
+                   cfg.block_size) => cfg.block_size;
 
     /* Write a single non-one to the second block */
     lfs_file_write(&lfs, &file, &bad_byte, 1) => 1;
     lfs_file_close(&lfs, &file) => 0;
 
     lfs_file_open(&lfs, &file, "barrier", LFS_O_RDWR) => 0;
-    lfs_file_truncate(&lfs, &file, cfg->block_size) => 0;
+    lfs_file_truncate(&lfs, &file, cfg.block_size) => 0;
     lfs_file_close(&lfs, &file) => 0;
 
     /* Read the first block, which should match buffer */
     lfs_file_open(&lfs, &file, "barrier", LFS_O_RDWR) => 0;
     lfs_file_read(&lfs, &file, rb,
-                  cfg->block_size) => cfg->block_size;
+                  cfg.block_size) => cfg.block_size;
     lfs_file_close(&lfs, &file) => 0;
 
     lfs_unmount(&lfs) => 0;
 
-    memcmp(buffer, rb, cfg->block_size) => 0;
+    memcmp(buffer, rb, cfg.block_size) => 0;
 '''

--- a/tests/test_truncate.toml
+++ b/tests/test_truncate.toml
@@ -437,3 +437,38 @@ code = '''
     lfs_file_close(&lfs, &file) => 0;
     lfs_unmount(&lfs) => 0;
 '''
+
+[[case]] # barrier truncate
+code = '''
+    lfs_format(&lfs, &cfg) => 0;
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_open(&lfs, &file, "barrier",
+            LFS_O_RDWR | LFS_O_CREAT) => 0;
+
+    uint8_t bad_byte = 2;
+    uint8_t *wb = buffer;
+    uint8_t *rb = buffer + cfg->block_size;
+
+    /* Write a series of 1s to the first block */
+    memset(buffer, 1, cfg->block_size);
+    lfs_file_write(&lfs, &file, buffer,
+                   cfg->block_size) => cfg->block_size;
+
+    /* Write a single non-one to the second block */
+    lfs_file_write(&lfs, &file, &bad_byte, 1) => 1;
+    lfs_file_close(&lfs, &file) => 0;
+
+    lfs_file_open(&lfs, &file, "barrier", LFS_O_RDWR) => 0;
+    lfs_file_truncate(&lfs, &file, cfg->block_size) => 0;
+    lfs_file_close(&lfs, &file) => 0;
+
+    /* Read the first block, which should match buffer */
+    lfs_file_open(&lfs, &file, "barrier", LFS_O_RDWR) => 0;
+    lfs_file_read(&lfs, &file, rb,
+                  cfg->block_size) => cfg->block_size;
+    lfs_file_close(&lfs, &file) => 0;
+
+    lfs_unmount(&lfs) => 0;
+
+    memcmp(buffer, rb, cfg->block_size) => 0;
+'''


### PR DESCRIPTION
Seemingly there's an issue where truncating a file to a block size causes the incorrect block to be referenced. Add this as a test case.

Signed-off-by: Colin Foster <colin.foster@in-advantage.com>